### PR TITLE
Fix watch task in tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,10 @@
             "command": "npm run watch",
             "group": "build",
             "problemMatcher": [
-                "$lessc"
+                "$lessc",
+                "$tsc",
+                "$tsc-watch",
+                "$lessCompile"
             ]
         },
         {


### PR DESCRIPTION
@timmccausland This will fix us not seeing the LESS compilation messages during the `watch` process that we saw during our screen share